### PR TITLE
Support namespaced git environment variables in Husky 1.x

### DIFF
--- a/lib/__tests__/git.test.js
+++ b/lib/__tests__/git.test.js
@@ -1,0 +1,23 @@
+const git = require('../git');
+
+describe('param', () => {
+  const ORIGINAL_ENV = Object.assign({}, process.env);
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test('looks for git parameters in GIT_PARAMS', () => {
+    process.env.GIT_PARAMS = 'foo bar';
+
+    expect(git.param(0)).toBe('foo');
+    expect(git.param(1)).toBe('bar');
+  });
+
+  test('looks for git parameters in HUSKY_GIT_PARAMS', () => {
+    process.env.HUSKY_GIT_PARAMS = 'baz qux';
+
+    expect(git.param(0)).toBe('baz');
+    expect(git.param(1)).toBe('qux');
+  });
+});

--- a/lib/git.js
+++ b/lib/git.js
@@ -20,10 +20,14 @@ Husky stashes git hook parameters $* into a GIT_PARAMS env var.
 This method reads indexed parameters back out of that variable.
 */
 exports.param = (index = 0) => {
+  // Husky 1.x namespaces GIT_PARAMS as HUSKY_GIT_PARAMS.
+  // For now I'm accommodating both.
+  const gitParams = process.env.HUSKY_GIT_PARAMS || process.env.GIT_PARAMS;
+
   // Unfortunately this will break if there are escaped spaces within
   // a single argument; I don't believe there's a workaround for this
   // without modifying Husky itself
-  return process.env.GIT_PARAMS.split(' ')[index];
+  return gitParams.split(' ')[index];
 };
 
 /**

--- a/lib/git.js
+++ b/lib/git.js
@@ -24,6 +24,10 @@ exports.param = (index = 0) => {
   // For now I'm accommodating both.
   const gitParams = process.env.HUSKY_GIT_PARAMS || process.env.GIT_PARAMS;
 
+  // Throw a friendly error if the git params environment variable
+  // can't be found – the user may be missing Husky.
+  if (!gitParams) throw new Error('Neither process.env.HUSKY_GIT_PARAMS nor process.env.GIT_PARAMS are set. Is a supported Husky version installed?');
+
   // Unfortunately this will break if there are escaped spaces within
   // a single argument; I don't believe there's a workaround for this
   // without modifying Husky itself


### PR DESCRIPTION
Husky 1.x renames the `GIT_PARAMS` environment variable to `HUSKY_GIT_PARAMS` to avoid collisions.

For now I'm supporting both variations in husky-pivotal, so users can upgrade to Husky 1.x without needing to upgrade husky-pivotal.